### PR TITLE
Add support for communicating with CDJ-3000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 lib
 docs
+.idea
+node_modules

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,7 +21,7 @@ async function cli() {
   );
 
   signale.await('Autoconfiguring network.. waiting for devices');
-  await network.autoconfigFromPeers();
+  await network.autoconfigFromPeers(true);
   signale.await('Autoconfigure successful!');
 
   signale.await('Connecting to network!');

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface Device {
   macAddr: Uint8Array;
   ip: Address4;
   lastActive?: Date;
+  enableCDJ3000Compatibility?: boolean;
 }
 
 /**

--- a/src/virtualcdj/index.ts
+++ b/src/virtualcdj/index.ts
@@ -17,12 +17,17 @@ import {buildName} from 'src/utils';
 /**
  * Constructs a virtual CDJ Device.
  */
-export const getVirtualCDJ = (iface: NetworkInterfaceInfoIPv4, id: DeviceID): Device => ({
+export const getVirtualCDJ = (
+  iface: NetworkInterfaceInfoIPv4,
+  id: DeviceID,
+  enableCDJ3000Compatibility: boolean
+): Device => ({
   id,
   name: VIRTUAL_CDJ_NAME,
   type: DeviceType.CDJ,
   ip: new ip.Address4(iface.address),
   macAddr: new Uint8Array(iface.mac.split(':').map(s => parseInt(s, 16))),
+  enableCDJ3000Compatibility: enableCDJ3000Compatibility,
 });
 
 /**
@@ -85,7 +90,12 @@ export function makeAnnouncePacket(deviceToAnnounce: Device): Uint8Array {
 
   // unknown padding bytes
   const unknown1 = [0x01, 0x02];
-  const unknown2 = [0x01, 0x00, 0x00, 0x00];
+  const unknown2 = [
+    deviceToAnnounce.enableCDJ3000Compatibility ? 0x02 : 0x01,
+    0x00,
+    0x00,
+    0x00,
+  ];
 
   // The packet blow is constructed in the following format:
   //
@@ -114,7 +124,7 @@ export function makeAnnouncePacket(deviceToAnnounce: Device): Uint8Array {
     ...d.ip.toArray(),
     ...unknown2,
     ...[d.type],
-    ...[0x00],
+    ...[deviceToAnnounce.enableCDJ3000Compatibility ? 0x64 : 0x00],
   ];
 
   return Uint8Array.from(parts);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,7 +1938,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.19.0, es-abstract@^1.19.5, es-abstract@^1.20.4:
+es-abstract@^1.19.0, es-abstract@^1.20.4:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.22.1.tgz#8b4e5fc5cefd7f1660f0f8e1a52900dfbc9d9ccc"
   integrity sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==
@@ -2460,7 +2460,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
   integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
@@ -3717,7 +3717,7 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-inspect@^1.12.2, object-inspect@^1.12.3, object-inspect@^1.9.0:
+object-inspect@^1.12.3, object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
@@ -4447,7 +4447,7 @@ string.prototype.trim@^1.2.7:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string.prototype.trimend@^1.0.5, string.prototype.trimend@^1.0.6:
+string.prototype.trimend@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
   integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
@@ -4456,7 +4456,7 @@ string.prototype.trimend@^1.0.5, string.prototype.trimend@^1.0.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string.prototype.trimstart@^1.0.5, string.prototype.trimstart@^1.0.6:
+string.prototype.trimstart@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
   integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==


### PR DESCRIPTION
Communication with a CDJ-3000 is different, see https://djl-analysis.deepsymmetry.org/djl-analysis/startup.html#startup-3000

This PR introduces the needed changes for this different communication while allowing backwards-compatibility.